### PR TITLE
APP-4495 ensure pending device inspections are cleared on stop

### DIFF
--- a/Source/Core/PltCtrlPoint.cpp
+++ b/Source/Core/PltCtrlPoint.cpp
@@ -327,6 +327,9 @@ PLT_CtrlPoint::Stop(PLT_SsdpListenTask* task)
     // as there are no more tasks pending
     m_RootDevices.Clear();
     m_Subscribers.Clear();
+	
+	m_PendingInspections.Clear();
+	m_PendingNotifications.Clear();
 
     m_EventHttpServer = NULL;
     m_TaskManager = NULL;


### PR DESCRIPTION
The issue was due to pending inspections from the previous run of platinum.  If platinum was in process of inspecting the device on stop, then on its next run when it found the device, it didn't inspect it because it thought it already was inspecting.

